### PR TITLE
Centered page title header

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -7,7 +7,9 @@ layout: default
 
       <div class="panel-heading">
 
-        <h1>{{ page.title }}</h1>
+        <div class="text-center">
+          <h1>{{ page.title }}</h1>
+        </div>
 
       </div>
       <div class="panel-body">


### PR DESCRIPTION
This centers the title for any page that uses the "page" layout.
