### PR TITLE
Added Woof Trax link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -21,6 +21,9 @@
       ·
       <!-- Amazon Smile link -->
       <a href="http://smile.amazon.com/about">Amazon Smile</a>
+      ·
+      <!-- Woof Trax link -->
+      <a href="http://www.wooftrax.com/">Woof Trax</a>
     </div>
     <p>
     &copy; Greyhound Pets of America-Central Texas<br>


### PR DESCRIPTION
Don’t just take your dog for a walk... Take your Walk for a Dog! Go to WoofTrax.com, download
the app, and support your local animal shelter every time you walk your dog.
